### PR TITLE
Update username to dependabot-preview

### DIFF
--- a/bulk_merger.rb
+++ b/bulk_merger.rb
@@ -72,7 +72,7 @@ class BulkMerger
   end
 
   def self.search_pull_requests(query)
-    client.search_issues("#{gem_name} archived:false is:pr user:alphagov state:open author:app/dependabot in:title #{query}").items
+    client.search_issues("#{gem_name} archived:false is:pr user:alphagov state:open author:app/dependabot-preview in:title #{query}").items
   end
 
   def self.client

--- a/spec/bulk_merger_spec.rb
+++ b/spec/bulk_merger_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe BulkMerger do
         ]
       }
 
-      stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=funky-gem-to-merge%20archived:false%20is:pr%20user:alphagov%20state:open%20author:app/dependabot%20in:title%20review:none%20funky-gem-to-merge").
+      stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=funky-gem-to-merge%20archived:false%20is:pr%20user:alphagov%20state:open%20author:app/dependabot-preview%20in:title%20review:none%20funky-gem-to-merge").
         to_return(body: JSON.dump(response), headers: { 'Content-Type' => 'application/json' })
 
       ENV["GEM_NAME"] = "funky-gem-to-merge"
@@ -46,7 +46,7 @@ RSpec.describe BulkMerger do
         ]
       }
 
-      stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=funky-gem-to-merge%20archived:false%20is:pr%20user:alphagov%20state:open%20author:app/dependabot%20in:title%20review:approved").
+      stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=funky-gem-to-merge%20archived:false%20is:pr%20user:alphagov%20state:open%20author:app/dependabot-preview%20in:title%20review:approved").
         to_return(body: JSON.dump(response), headers: { 'Content-Type' => 'application/json' })
 
       ENV["GEM_NAME"] = "funky-gem-to-merge"


### PR DESCRIPTION
This has changed since Dependabot was bought by GitHub.

Related to https://github.com/alphagov/govuk-dependencies/pull/73.