### PR TITLE
Only show PRs that have fully passed CI checks

### DIFF
--- a/bulk_merger.rb
+++ b/bulk_merger.rb
@@ -72,7 +72,7 @@ class BulkMerger
   end
 
   def self.search_pull_requests(query)
-    client.search_issues("#{gem_name} archived:false is:pr user:alphagov state:open author:app/dependabot-preview in:title #{query}").items
+    client.search_issues("#{gem_name} archived:false is:pr user:alphagov state:open author:app/dependabot-preview status:success in:title #{query}").items
   end
 
   def self.find_govuk_pull_requests(query)


### PR DESCRIPTION
- Before, we were showing all PRs and bulk approving or merging all of
  them. In the case of merging, this would fail with an error from GitHub
  as our branch protection rules prevent us from merging a PR with failing
  or unsuccessful checks.
- We also shouldn't be approving PRs with failed checks.
- This now only surfaces PRs that have _completely_ passed the required
  number of checks according to GitHub, with the `status:success`
  filter.