### PR TITLE
Cache GOV.UK repos and revert only showing status:success PRs.

### DIFF
--- a/bulk_merger.rb
+++ b/bulk_merger.rb
@@ -75,12 +75,16 @@ class BulkMerger
     client.search_issues("#{gem_name} archived:false is:pr user:alphagov state:open author:app/dependabot-preview status:success in:title #{query}").items
   end
 
-  def self.find_govuk_pull_requests(query)
-    # Only search non-archived repos tagged with `govuk`.
-    repos = client.search_repos("org:alphagov topic:govuk").items.reject!(&:archived)
+  def self.govuk_repos
+    @govuk_repos ||= client.search_repos("org:alphagov topic:govuk")
+      .items
+      .reject!(&:archived)
+      .map { |repo| repo.full_name }
+  end
 
+  def self.find_govuk_pull_requests(query)
     search_pull_requests(query).select do |pr|
-      repos.any? { |repo| pr.repository_url.include?(repo.full_name) }
+      govuk_repos.any? { |repo| pr.repository_url.include?(repo) }
     end
   end
 

--- a/bulk_merger.rb
+++ b/bulk_merger.rb
@@ -72,7 +72,7 @@ class BulkMerger
   end
 
   def self.search_pull_requests(query)
-    client.search_issues("#{gem_name} archived:false is:pr user:alphagov state:open author:app/dependabot-preview status:success in:title #{query}").items
+    client.search_issues("#{gem_name} archived:false is:pr user:alphagov state:open author:app/dependabot-preview in:title #{query}").items
   end
 
   def self.govuk_repos


### PR DESCRIPTION
This caches the query which finds the GOV.UK repos to improve performance, and also reverts https://github.com/alphagov/bulk-merger/commit/ff91eaa0b1a3f079216523f909082b068b35e67e because it seems to have prevented PRs from appearing in the list.

For example: [status:success](https://github.com/alphagov/calculators/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+author%3Aapp%2Fdependabot-preview+status%3Asuccess) vs [non status:success](https://github.com/alphagov/calculators/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+author%3Aapp%2Fdependabot-preview)