### PR TITLE
Also search for PRs under dependabot

### DIFF
--- a/bulk_merger.rb
+++ b/bulk_merger.rb
@@ -72,7 +72,7 @@ class BulkMerger
   end
 
   def self.search_pull_requests(query)
-    client.search_issues("#{gem_name} archived:false is:pr user:alphagov state:open author:app/dependabot-preview in:title #{query}").items
+    client.search_issues("#{gem_name} archived:false is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview in:title #{query}").items
   end
 
   def self.govuk_repos


### PR DESCRIPTION
The automatic GitHub security vulnerability feature opens PRs under the name of `dependabot` rather than `dependabot-preview`.