### PR TITLE
Add a `list` command and accompanying Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,3 +15,8 @@ desc "Merge approved pull requests, without reviewing"
 task :merge_only do
   BulkMerger.merge_approved_pull_requests!
 end
+
+desc "List un-reviewed pull requests"
+task :list do
+  BulkMerger.approve_unreviewed_pull_requests!(list: true)
+end

--- a/bulk_merger.rb
+++ b/bulk_merger.rb
@@ -1,7 +1,7 @@
 require "octokit"
 
 class BulkMerger
-  def self.approve_unreviewed_pull_requests!
+  def self.approve_unreviewed_pull_requests!(list: nil)
     puts "Searching for Dependabot PRs for gem '#{gem_name}'"
 
     unreviewed_pull_requests = find_govuk_pull_requests("review:none #{gem_name}")
@@ -16,6 +16,8 @@ class BulkMerger
     unreviewed_pull_requests.each do |pr|
       puts "- '#{pr.title}' (#{pr.html_url}) "
     end
+
+    return if list
 
     puts "\nHave you reviewed the changes, and you want to approve all these PRs? [y/N]\n"
     if STDIN.gets.chomp == "y"

--- a/list
+++ b/list
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source .env
+export GEM_NAME=$1
+bundle exec rake list


### PR DESCRIPTION
- Sometimes you don't want to ^C or type N on the `review` command to not bulk-approve PRs, but you want to see the existing ones. This `list` command and accompanying `rake list` task does that by setting an envvar `LIST` that doesn't show any of the "approving Y/N" options and calling any of the approval/merge APIs.
- This is especially useful while you can't search for PRs by repo `topic` via the GitHub APIs.