### PR TITLE
Enable bulk actions on other PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bulk merger
 
-Bulk merge Pull Requests from Dependabot.
+Bulk merge Pull Requests for GOV.UK repos.
 
 ## Setup
 
@@ -19,13 +19,13 @@ The scripts will use this token to talk to GitHub.
 ./review gds-api-adapters
 ```
 
-This looks for unreviewed Dependabot PRs in `alphagov` with "gds-api-adapters" in the title. If it finds any, it will list them out and ask you to confirm if you want to approve them.
+This looks for unreviewed PRs in `alphagov` with "gds-api-adapters" in the title. If it finds any, it will list them out and ask you to confirm if you want to approve them.
 
 Use this command for third-party libraries that need [a second GOV.UK reviewer](https://docs.publishing.service.gov.uk/manual/manage-ruby-dependencies.html#who-can-merge-dependabot-prs).
 
 ```shell
 @tijmenb ~/govuk/bulk-merger on master $ ./review gds-api-adapters
-Searching for Dependabot PRs for gem 'gds-api-adapters'
+Searching for PRs containing 'gds-api-adapters'
 Found 3 unreviewed PRs:
 
 - 'Bump gds-api-adapters from 53.2.0 to 54.0.0' (https://github.com/alphagov/short-url-manager/pull/262)
@@ -47,8 +47,6 @@ Reviewing PR 'Bump gds-api-adapters from 53.2.0 to 54.0.0' (https://github.com/a
 ```
 
 This will run the `./review` script above, but also merge the approved PRs.
-
-Use this command for gems that are owned by GOV.UK [and can be merged without a second reviewer](https://docs.publishing.service.gov.uk/manual/manage-ruby-dependencies.html#who-can-merge-dependabot-prs).
 
 Because all repos have [branch protection turned on](https://docs.publishing.service.gov.uk/manual/configure-github-repo.html), you won't be able to merge PRs that haven't passed on CI.
 

--- a/bulk_merger.rb
+++ b/bulk_merger.rb
@@ -2,9 +2,9 @@ require "octokit"
 
 class BulkMerger
   def self.approve_unreviewed_pull_requests!(list: nil)
-    puts "Searching for Dependabot PRs for gem '#{gem_name}'"
+    puts "Searching for PRs containing '#{query_string}'"
 
-    unreviewed_pull_requests = find_govuk_pull_requests("review:none #{gem_name}")
+    unreviewed_pull_requests = find_govuk_pull_requests("review:none #{query_string}")
 
     if unreviewed_pull_requests.size == 0
       puts "No unreviewed PRs found!"
@@ -38,7 +38,7 @@ class BulkMerger
   end
 
   def self.merge_approved_pull_requests!
-    unmerged_pull_requests = find_govuk_pull_requests("review:approved")
+    unmerged_pull_requests = find_govuk_pull_requests("review:approved #{query_string}")
 
     if unmerged_pull_requests.size == 0
       puts "No unmerged PRs found!"
@@ -74,7 +74,7 @@ class BulkMerger
   end
 
   def self.search_pull_requests(query)
-    client.search_issues("#{gem_name} archived:false is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview in:title #{query}").items
+    client.search_issues("#{query} archived:false is:pr user:alphagov state:open in:title").items
   end
 
   def self.govuk_repos
@@ -94,7 +94,7 @@ class BulkMerger
     @client ||= Octokit::Client.new(access_token: ENV.fetch("GITHUB_TOKEN"), auto_paginate: true)
   end
 
-  def self.gem_name
-    ENV.fetch("GEM_NAME")
+  def self.query_string
+    ENV.fetch("QUERY_STRING")
   end
 end

--- a/merge
+++ b/merge
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 source .env
-export GEM_NAME=$1
+export QUERY_STRING=$1
 bundle exec rake merge

--- a/merge_only
+++ b/merge_only
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 source .env
-export GEM_NAME=$1
+export QUERY_STRING=$1
 bundle exec rake merge_only

--- a/review
+++ b/review
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 source .env
-export GEM_NAME=$1
+export QUERY_STRING=$1
 bundle exec rake review


### PR DESCRIPTION
This relaxes the query mechanism to enable bulk actions on all PRs,
while still supporting dependabot-specific ones.