### PR TITLE
Confirm that you will release any merged apps

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,49 @@
 require_relative "bulk_merger"
 
+desc "Confirm that you will release everything you merge"
+task :confirm do
+  required_confirmation = "I promise to release everything I merge"
+
+  puts <<~CONFIRMATION
+  Bulk merging pull requests should only be done if you're willing to ensure
+  that every application is released to production.
+
+  This is useful for things like security patches, which need to be merged
+  across lots of applications quickly.
+
+  However, in most cases it's more sensible to approve, merge, and release each
+  application individually. This reduces the risk of having unreleased changes
+  on the main branch.
+
+  Please confirm that you understand this, and that you will release all the
+  things you've merged by typing exactly:
+
+  #{required_confirmation}
+
+  CONFIRMATION
+
+  confirmation = STDIN.gets.chomp
+
+  if confirmation == required_confirmation
+    puts "Okay then. You better do.\n"
+  else
+    abort "Please type exactly '#{required_confirmation}' to confirm"
+  end
+end
+
 desc "Just approve pull requests"
 task :review do
   BulkMerger.approve_unreviewed_pull_requests!
 end
 
 desc "Approve & merge pull requests"
-task :merge do
+task :merge => :confirm do
   BulkMerger.approve_unreviewed_pull_requests!
   BulkMerger.merge_approved_pull_requests!
 end
 
 desc "Merge approved pull requests, without reviewing"
-task :merge_only do
+task :merge_only => :confirm do
   BulkMerger.merge_approved_pull_requests!
 end
 


### PR DESCRIPTION
We often end up in a situation where lots of gem version bumps have been
merged, but they haven't been released. Sometimes, this is because this
tool has been used to quickly merge a version bump across lots of
applications, where perhaps only some of the apps are actually affected.
The affected applications usually get released, but others end up with
changes on the main branch that aren't deployed to production.

This is very risky. When there are unexpected incompatibilities with a
version bump, we won't discover them close to the time of the merge when
someone has enough context to work out what's wrong. We'll discover them
weeks or months later, when some poor soul decides to release the
application to get a different, unrelated change out.

To try to discourage people from using this tool in inappropriate
situations, I've added an annoying confirmation message to the `merge`
and `merge_only` tasks. The user must type "I promise to release
everything I merge" before the tool will do the merges now.

I'm not joking about this. I genuinely think this will help nudge
people's incentives in the right direction. Some of my wording might be
a bit aggressive though - happy to work on that if people think it's
needed.