### PR TITLE
Improve error handling and get rid of some code duplication.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'octokit'
 gem 'rake'
+gem 'faraday-retry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,8 @@ GEM
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.3)
+    faraday-retry (2.0.0)
+      faraday (~> 2.0)
     octokit (5.1.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -21,6 +23,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  faraday-retry
   octokit
   rake
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require_relative "bulk_merger"
 
+abort('abort: GITHUB_TOKEN not set in environment.') unless ENV['GITHUB_TOKEN']
+
 desc "Confirm that you will release everything you merge"
 task :confirm do
   required_confirmation = "I promise to release everything I merge"

--- a/bulk-merger.sh
+++ b/bulk-merger.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eu
+
+cmd=$(basename "$0")
+[[ -z "$*" ]] && echo 'usage: ./[list|merge|merge_only|review] query_string' && exit 64
+[[ -r ".env" ]] && source .env
+
+export QUERY_STRING="$*"
+bundle exec rake $cmd

--- a/bulk-merger.sh
+++ b/bulk-merger.sh
@@ -6,4 +6,4 @@ cmd=$(basename "$0")
 [[ -r ".env" ]] && source .env
 
 export QUERY_STRING="$*"
-bundle exec rake $cmd
+bundle exec rake "$cmd"

--- a/list
+++ b/list
@@ -1,5 +1,1 @@
-#!/usr/bin/env bash
-
-source .env
-export GEM_NAME=$1
-bundle exec rake list
+bulk-merger.sh

--- a/merge
+++ b/merge
@@ -1,5 +1,1 @@
-#!/usr/bin/env bash
-
-source .env
-export QUERY_STRING=$1
-bundle exec rake merge
+bulk-merger.sh

--- a/merge_only
+++ b/merge_only
@@ -1,5 +1,1 @@
-#!/usr/bin/env bash
-
-source .env
-export QUERY_STRING=$1
-bundle exec rake merge_only
+bulk-merger.sh

--- a/review
+++ b/review
@@ -1,5 +1,1 @@
-#!/usr/bin/env bash
-
-source .env
-export QUERY_STRING=$1
-bundle exec rake review
+bulk-merger.sh


### PR DESCRIPTION
* Get rid of the ominous `To use retry middleware with Faraday v2.0+, install faraday-retry gem` warning message that was being printed on every invocation.
* Replace the duplicated shell scripts (that basically differed by just one string) with a single script that's symlinked for each of the four commands. This also fixes the `list` command, whose script was setting the wrong environment variable.
* Print a helpful error message when `GITHUB_TOKEN` is missing from the environment.
* Don't complain when the file `.env` doesn't exist. (We only care that `GITHUB_TOKEN` is set; we don't care how.)

#### Testing

```
$ ./list
usage: ./[list|merge|merge_only|review] query_string
```
```
$ ./list ''
usage: ./[list|merge|merge_only|review] query_string
```
```
$ unset GITHUB_TOKEN
$ ./list foo
abort: GITHUB_TOKEN not set in environment.
```
```
$ ./list 'Gem publish workflow'
Searching for PRs containing 'Gem publish workflow'
No unreviewed PRs found!
```
```
$ ./list 'Fastly CDN'
Searching for PRs containing 'Fastly CDN'
Found 1 unreviewed PRs:

- 'Fastly cdn terraform' (https://github.com/alphagov/govuk-infrastructure/pull/203)
```
```
$ ./review 'Fastly CDN'
Searching for PRs containing 'Fastly CDN'
Found 1 unreviewed PRs:

- 'Fastly cdn terraform' (https://github.com/alphagov/govuk-infrastructure/pull/203)

Have you reviewed the changes, and you want to approve all these PRs? [y/N]
n
👋
```
```
$ ./merge 'Fastly CDN'
Bulk merging pull requests should only be done if you're willing to ensure
that every application is released to production.

This is useful for things like security patches, which need to be merged
across lots of applications quickly.

However, in most cases it's more sensible to approve, merge, and release each
application individually. This reduces the risk of having unreleased changes
on the main branch.

Please confirm that you understand this, and that you will release all the
things you've merged by typing exactly:

I promise to release everything I merge

I promise to release everything I merge
Okay then. You better do.
Searching for PRs containing 'Fastly CDN'
Found 1 unreviewed PRs:

- 'Fastly cdn terraform' (https://github.com/alphagov/govuk-infrastructure/pull/203) 

Have you reviewed the changes, and you want to approve all these PRs? [y/N]
n
👋
```
```
$ ./merge_only 'Fastly CDN'
Bulk merging pull requests should only be done if you're willing to ensure
that every application is released to production.

This is useful for things like security patches, which need to be merged
across lots of applications quickly.

However, in most cases it's more sensible to approve, merge, and release each
application individually. This reduces the risk of having unreleased changes
on the main branch.

Please confirm that you understand this, and that you will release all the
things you've merged by typing exactly:

I promise to release everything I merge

I promise to release everything I merge
Okay then. You better do.
No unmerged PRs found!
```
```
$ ./merge_only 'Gem publish workflow'
Bulk merging pull requests should only be done if you're willing to ensure
that every application is released to production.

This is useful for things like security patches, which need to be merged
across lots of applications quickly.

However, in most cases it's more sensible to approve, merge, and release each
application individually. This reduces the risk of having unreleased changes
on the main branch.

Please confirm that you understand this, and that you will release all the
things you've merged by typing exactly:

I promise to release everything I merge

I promise to release everything I merge
Okay then. You better do.
Found 4 reviewed but unmerged PRs:

- 'Use shared workflow to publish gem' (https://github.com/alphagov/govuk_app_config/pull/247)
- 'Use shared workflow to publish gem' (https://github.com/alphagov/govuk_admin_template/pull/243)
- 'Use shared workflow to publish gem' (https://github.com/alphagov/govuk-connect/pull/73)
- 'Gem publish workflow be resilient to out of order executions' (https://github.com/alphagov/govuk-infrastructure/pull/688)

Have you reviewed the changes, and you want to MERGE all these PRs? [y/N]
n
👋
```