### PR TITLE
Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,1 @@
-version: 2
-updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "03:00"
-  open-pull-requests-limit: 10
+---


### PR DESCRIPTION
Disable Dependabot for all dependencies while the npmjs security incident is ongoing